### PR TITLE
Remove Registrar

### DIFF
--- a/android/src/main/kotlin/io/agora/agorartm/AgoraRtmPlugin.kt
+++ b/android/src/main/kotlin/io/agora/agorartm/AgoraRtmPlugin.kt
@@ -19,10 +19,8 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 class AgoraRtmPlugin : FlutterPlugin, MethodCallHandler {
-    private var registrar: Registrar? = null
     private var binding: FlutterPlugin.FlutterPluginBinding? = null
     private lateinit var applicationContext: Context
     private lateinit var methodChannel: MethodChannel
@@ -30,16 +28,6 @@ class AgoraRtmPlugin : FlutterPlugin, MethodCallHandler {
     private val handler: Handler = Handler(Looper.getMainLooper())
     private var nextClientIndex: Long = 0
     private var clients = HashMap<Long, RTMClient>()
-
-    companion object {
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            AgoraRtmPlugin().apply {
-                this.registrar = registrar
-                initPlugin(registrar.context(), registrar.messenger())
-            }
-        }
-    }
 
     private fun initPlugin(
         context: Context, binaryMessenger: BinaryMessenger
@@ -183,7 +171,7 @@ class AgoraRtmPlugin : FlutterPlugin, MethodCallHandler {
                     applicationContext,
                     appId,
                     nextClientIndex,
-                    registrar?.messenger() ?: binding!!.binaryMessenger,
+                    binding!!.binaryMessenger,
                     handler
                 )
                 object : Callback<Long>(result, handler) {}.onSuccess(nextClientIndex)
@@ -256,7 +244,7 @@ class AgoraRtmPlugin : FlutterPlugin, MethodCallHandler {
                     val agoraRtmChannel = RTMChannel(
                         clientIndex,
                         channelId,
-                        registrar?.messenger() ?: binding!!.binaryMessenger,
+                        binding!!.binaryMessenger,
                         handler
                     )
                     client.createChannel(channelId, agoraRtmChannel)?.let {


### PR DESCRIPTION
flutter3.29.0でAndroidビルドするとエラーになるため、Registrarに関連するコードを削除しました。
